### PR TITLE
build: add from_py_object to pyclass

### DIFF
--- a/src/adjoint_checkpoint.rs
+++ b/src/adjoint_checkpoint.rs
@@ -4,7 +4,7 @@
 
 use pyo3::prelude::*;
 
-#[pyclass(module = "pydiffsol")]
+#[pyclass(from_py_object, module = "pydiffsol")]
 #[pyo3(name = "AdjointCheckpoint")]
 #[derive(Clone)]
 pub struct AdjointCheckpointWrapper(diffsol_c::AdjointCheckpointWrapper);

--- a/src/jit.rs
+++ b/src/jit.rs
@@ -4,7 +4,7 @@ use pyo3::{
     types::{PyList, PyType},
 };
 
-#[pyclass(eq)]
+#[pyclass(from_py_object, eq)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum JitBackendType {
     #[cfg(feature = "diffsol-cranelift")]

--- a/src/linear_solver_type.rs
+++ b/src/linear_solver_type.rs
@@ -13,7 +13,7 @@ use pyo3::{
 /// :attr default: use the solver's default linear solver choice, typically LU
 /// :attr lu: use LU decomposition linear solver (dense or sparse as appropriate)
 /// :attr klu: use KLU sparse linear solver
-#[pyclass(eq)]
+#[pyclass(from_py_object, eq)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum LinearSolverType {
     #[pyo3(name = "default")]

--- a/src/matrix_type.rs
+++ b/src/matrix_type.rs
@@ -12,7 +12,7 @@ use pyo3::{
 /// :attr nalgebra_dense: dense matrix using nalgebra crate (https://nalgebra.rs/)
 /// :attr faer_dense: dense matrix using faer crate (https://faer.veganb.tw/)
 /// :attr faer_sparse: sparse matrix using faer crate (https://faer.veganb.tw/)
-#[pyclass(eq)]
+#[pyclass(from_py_object, eq)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum MatrixType {
     #[pyo3(name = "nalgebra_dense")]

--- a/src/ode.rs
+++ b/src/ode.rs
@@ -27,7 +27,7 @@ use crate::{
     solution::SolutionWrapper,
 };
 
-#[pyclass(module = "pydiffsol")]
+#[pyclass(from_py_object, module = "pydiffsol")]
 #[pyo3(name = "Ode")]
 #[derive(Clone)]
 pub struct OdeWrapper(diffsol_c::OdeWrapper);

--- a/src/ode_solver_type.rs
+++ b/src/ode_solver_type.rs
@@ -7,7 +7,7 @@ use pyo3::{
     types::{PyList, PyType},
 };
 
-#[pyclass(eq)]
+#[pyclass(from_py_object, eq)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum OdeSolverType {
     #[pyo3(name = "bdf")]

--- a/src/options_ic.rs
+++ b/src/options_ic.rs
@@ -2,7 +2,7 @@ use pyo3::prelude::*;
 
 use crate::error::PyDiffsolError;
 
-#[pyclass]
+#[pyclass(from_py_object)]
 #[derive(Clone)]
 pub struct InitialConditionSolverOptions(diffsol_c::InitialConditionSolverOptions);
 

--- a/src/options_ode.rs
+++ b/src/options_ode.rs
@@ -2,7 +2,7 @@ use pyo3::prelude::*;
 
 use crate::error::PyDiffsolError;
 
-#[pyclass]
+#[pyclass(from_py_object)]
 #[derive(Clone)]
 pub struct OdeSolverOptions(diffsol_c::OdeSolverOptions);
 

--- a/src/scalar_type.rs
+++ b/src/scalar_type.rs
@@ -6,7 +6,7 @@ use pyo3::{
     types::{PyList, PyType},
 };
 
-#[pyclass(eq)]
+#[pyclass(from_py_object, eq)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum ScalarType {
     #[pyo3(name = "f32")]

--- a/src/solution.rs
+++ b/src/solution.rs
@@ -6,7 +6,7 @@ use crate::error::PyDiffsolError;
 use crate::host_array::{host_array_to_py, host_array_vec_to_py};
 
 #[pyclass]
-#[pyo3(name = "Solution")]
+#[pyo3(from_py_object, name = "Solution")]
 #[derive(Clone)]
 pub struct SolutionWrapper(diffsol_c::SolutionWrapper);
 


### PR DESCRIPTION
- PyO3 is phasing out the automatic implementation of FromPyObject for types that implement Clone. In the docs see 'from 0.27.* to 0.28' and 'Deprecation of automatic FromPyObject for #[pyclass] types which implement Clone'.
- For now, I'm going adding from_py_object everywhere so it's the same as previous behaviour