### PR TITLE
docs: update urllib3 dep in sphinx

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -16,7 +16,7 @@ docutils==0.22.4
     # via
     #   sphinx
     #   sphinx-rtd-theme
-idna==3.13
+idna==3.14
     # via requests
 imagesize==2.0.0
     # via sphinx
@@ -32,7 +32,7 @@ pydiffsol==0.5.0
     # via -r requirements.in
 pygments==2.20.0
     # via sphinx
-requests==2.33.1
+requests==2.34.0
     # via sphinx
 roman-numerals==4.1.0
     # via sphinx
@@ -59,5 +59,5 @@ sphinxcontrib-qthelp==2.0.0
     # via sphinx
 sphinxcontrib-serializinghtml==2.0.0
     # via sphinx
-urllib3==2.6.3
+urllib3==2.7.0
     # via requests


### PR DESCRIPTION
- rerun `pip-compile --upgrade requirements.in` in response to CVE picked up by dependabot in docs build: Dependency urllib3 Version >= 2.6.0 < 2.7.0 Upgrade to ~> 2.7.0 Defined in requirements.txt Vulnerabilities CVE-2026-44432 High severity CVE-2026-44431 High severity