### PR TITLE
ci: try with lto for faer runtime

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -48,13 +48,13 @@ jobs:
             curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain stable -y
             source .github/scripts/maturin_linux_setup.sh
           CIBW_ENVIRONMENT_LINUX: >-
-            MATURIN_PEP517_ARGS="--features diffsol-llvm17 --features suitesparse"
+            MATURIN_PEP517_ARGS="-vv --features diffsol-llvm17 --features suitesparse"
             RUSTFLAGS="-C linker-features=-lld"
           CIBW_ENVIRONMENT_MACOS: >-
             MACOSX_DEPLOYMENT_TARGET=14.0
-            MATURIN_PEP517_ARGS="--features diffsol-llvm17"
+            MATURIN_PEP517_ARGS="-vv --features diffsol-llvm17"
           CIBW_ENVIRONMENT_WINDOWS: >-
-            MATURIN_PEP517_ARGS="--features diffsol-cranelift"
+            MATURIN_PEP517_ARGS="-vv --features diffsol-cranelift"
       - name: Upload wheels
         uses: actions/upload-artifact@v7
         with:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -49,6 +49,7 @@ jobs:
             source .github/scripts/maturin_linux_setup.sh
           CIBW_ENVIRONMENT_LINUX: >-
             MATURIN_PEP517_ARGS="--features diffsol-llvm17 --features suitesparse"
+            RUSTFLAGS="-C linker-features=-lld"
           CIBW_ENVIRONMENT_MACOS: >-
             MACOSX_DEPLOYMENT_TARGET=14.0
             MATURIN_PEP517_ARGS="--features diffsol-llvm17"

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -50,7 +50,7 @@ jobs:
             source .github/scripts/maturin_linux_setup.sh
           CIBW_ENVIRONMENT_LINUX: >-
             MATURIN_PEP517_ARGS="--features diffsol-llvm17 --features suitesparse"
-            RUSTFLAGS="-C lto=thin -C codegen-units=1"
+            RUSTFLAGS="-C linker-features=-lld -C lto=thin -C codegen-units=1"
           CIBW_ENVIRONMENT_MACOS: >-
             MACOSX_DEPLOYMENT_TARGET=14.0
             MATURIN_PEP517_ARGS="--features diffsol-llvm17"

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -50,7 +50,7 @@ jobs:
             source .github/scripts/maturin_linux_setup.sh
           CIBW_ENVIRONMENT_LINUX: >-
             MATURIN_PEP517_ARGS="--features diffsol-llvm17 --features suitesparse"
-            RUSTFLAGS="-C linker-features=-lld -C lto=thin -C codegen-units=1"
+            RUSTFLAGS="-C linker-features=-lld -C embed-bitcode=yes -C lto=thin -C codegen-units=1"
           CIBW_ENVIRONMENT_MACOS: >-
             MACOSX_DEPLOYMENT_TARGET=14.0
             MATURIN_PEP517_ARGS="--features diffsol-llvm17"

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -21,11 +21,10 @@ jobs:
         platform:
           - runner: ubuntu-22.04
             target: x86_64
-          # FIXME enable lto on other platforms
-          # - runner: windows-latest
-          #   target: AMD64
-          # - runner: macos-14
-          #   target: arm64
+          - runner: windows-latest
+            target: AMD64
+          - runner: macos-14
+            target: arm64
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-python@v6

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -21,10 +21,10 @@ jobs:
         platform:
           - runner: ubuntu-22.04
             target: x86_64
-          # - runner: windows-latest
-          #   target: AMD64
-          # - runner: macos-14
-          #   target: arm64
+          - runner: windows-latest
+            target: AMD64
+          - runner: macos-14
+            target: arm64
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-python@v6
@@ -48,13 +48,13 @@ jobs:
             curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain stable -y
             source .github/scripts/maturin_linux_setup.sh
           CIBW_ENVIRONMENT_LINUX: >-
-            MATURIN_PEP517_ARGS="-vv --features diffsol-llvm17 --features suitesparse"
+            MATURIN_PEP517_ARGS="--features diffsol-llvm17 --features suitesparse"
             RUSTFLAGS="-C linker-features=-lld"
           CIBW_ENVIRONMENT_MACOS: >-
             MACOSX_DEPLOYMENT_TARGET=14.0
-            MATURIN_PEP517_ARGS="-vv --features diffsol-llvm17"
+            MATURIN_PEP517_ARGS="--features diffsol-llvm17"
           CIBW_ENVIRONMENT_WINDOWS: >-
-            MATURIN_PEP517_ARGS="-vv --features diffsol-cranelift"
+            MATURIN_PEP517_ARGS="--features diffsol-cranelift"
       - name: Upload wheels
         uses: actions/upload-artifact@v7
         with:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -50,7 +50,6 @@ jobs:
             source .github/scripts/maturin_linux_setup.sh
           CIBW_ENVIRONMENT_LINUX: >-
             MATURIN_PEP517_ARGS="--features diffsol-llvm17 --features suitesparse"
-            RUSTFLAGS="-C linker-features=-lld"
           CIBW_ENVIRONMENT_MACOS: >-
             MACOSX_DEPLOYMENT_TARGET=14.0
             MATURIN_PEP517_ARGS="--features diffsol-llvm17"

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -50,7 +50,7 @@ jobs:
             source .github/scripts/maturin_linux_setup.sh
           CIBW_ENVIRONMENT_LINUX: >-
             MATURIN_PEP517_ARGS="--features diffsol-llvm17 --features suitesparse"
-            RUSTFLAGS="-C linker-features=-lld -C embed-bitcode=yes -C lto=thin -C codegen-units=1"
+            RUSTFLAGS="-C linker-features=-lld"
           CIBW_ENVIRONMENT_MACOS: >-
             MACOSX_DEPLOYMENT_TARGET=14.0
             MATURIN_PEP517_ARGS="--features diffsol-llvm17"

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -21,10 +21,10 @@ jobs:
         platform:
           - runner: ubuntu-22.04
             target: x86_64
-          - runner: windows-latest
-            target: AMD64
-          - runner: macos-14
-            target: arm64
+          # - runner: windows-latest
+          #   target: AMD64
+          # - runner: macos-14
+          #   target: arm64
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-python@v6

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -21,10 +21,11 @@ jobs:
         platform:
           - runner: ubuntu-22.04
             target: x86_64
-          - runner: windows-latest
-            target: AMD64
-          - runner: macos-14
-            target: arm64
+          # FIXME enable lto on other platforms
+          # - runner: windows-latest
+          #   target: AMD64
+          # - runner: macos-14
+          #   target: arm64
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-python@v6
@@ -49,7 +50,7 @@ jobs:
             source .github/scripts/maturin_linux_setup.sh
           CIBW_ENVIRONMENT_LINUX: >-
             MATURIN_PEP517_ARGS="--features diffsol-llvm17 --features suitesparse"
-            RUSTFLAGS="-C linker-features=-lld"
+            RUSTFLAGS="-C lto=thin -C codegen-units=1"
           CIBW_ENVIRONMENT_MACOS: >-
             MACOSX_DEPLOYMENT_TARGET=14.0
             MATURIN_PEP517_ARGS="--features diffsol-llvm17"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,5 +34,9 @@ pyo3 = { version = "*", features = [
   "auto-initialize"
 ] }
 
+[profile.dev]
+lto = true
+codegen-units = 1
+
 [build-dependencies]
 cargo-lock = "11.0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,8 +33,8 @@ serde_json = "1.0"
 [dev-dependencies]
 pyo3 = { workspace = true, features = ["auto-initialize"] }
 
-[profile.dev]
-lto = true
+[profile.release]
+lto = "thin"
 codegen-units = 1
 
 [build-dependencies]


### PR DESCRIPTION
- found to resolve a performance regression in diffsol caused by inlining changing in faer dependency.
- lld disabled for this first build in case of flags conflict.